### PR TITLE
Interpolate number intro string

### DIFF
--- a/lib/polymer_ajax/polymer_ajax.dart
+++ b/lib/polymer_ajax/polymer_ajax.dart
@@ -137,7 +137,7 @@ class PolymerAjax extends PolymerElement {
   }
 
   _error(xhr) {
-    var response = xhr.status + ': ' + xhr.responseText;
+    var response = '${xhr.status}: ${xhr.responseText}';
     this.fire('polymererror', detail: {'response': response, 'xhr': xhr});
   }
 


### PR DESCRIPTION
Prevents the attempt to add a string to an integer, which had resulted in a runtime error.

Otherwise, we get the following on errors:

```
NoSuchMethodError : method not found: '_addFromInteger@0x36924d72'
Receiver: ": "
Arguments: [0]
Stack Trace: 
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:42)
#1      int.+ (dart:core-patch/integers.dart:16)
#2      PolymerAjax._error (http://localhost:8080/packages/polymer_elements/polymer_ajax/polymer_ajax.dart:129:31)
#3      _receive (http://localhost:8080/packages/polymer_elements/polymer_ajax/polymer_ajax.dart:112:18)
#4      PolymerXhr._makeReadyStateHandler.<anonymous closure> (http://localhost:8080/packages/polymer_elements/polymer_ajax/polymer_xhr.dart:33:17)
```
