### PR TITLE
Remove polymer_ui_elements dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: polymer_elements
 version: 0.1.2
-authors: 
+authors:
 - Erik Grimes <erik.grimes@gmail.com>
 - Günter Zöchbauer <guenter@gzoechbauer.com>
 description: >
-  A Dart port of polymer-elements 
+  A Dart port of polymer-elements
   (https://github.com/Polymer/polymer-elements).
 homepage: https://github.com/ErikGrimes/polymer_elements
 documentation: http://erikgrimes.github.io/polymer_elements/docs/index.html
@@ -12,10 +12,6 @@ environment:
   sdk: ">=1.0.0 <2.0.0"
 dependencies:
   polymer: ">=0.9.2+3 <0.10.0"
-  polymer_ui_elements: ">=0.1.1 <0.2.0"
-#dependency_overrides:
-#  polymer_ui_elements: 
-#    path: ../polymer_ui_elements  
 dev_dependencies:
   unittest: ">=0.9.0 <0.10.0"
 transformers:


### PR DESCRIPTION
I believe that this was causing a circular dependency since
polymer_ui_elements also depended on this package. The end result (at
least for me locally) was that pub serve would not serve resources
from either package.

More info at: http://japhr.blogspot.com/2013/12/pub-server-polymer-elements.html

Also, should polymer_ui_elements be dependent on this package? It 
seems like they ought to be completely independent of each other.
